### PR TITLE
Fix/readme and version

### DIFF
--- a/Packages/ButtplugUnity/CHANGELOG.md
+++ b/Packages/ButtplugUnity/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2.1.0 (2021-05-10)
+
+## Features
+
+- Add in binary files
+- Reorganize files to support full Unity-compatible example project
+- Improve example C# script with intensity slider and connected device list in Inspector
+
 # 2.0.0 (2021-04-24)
 
 ## Features

--- a/Packages/ButtplugUnity/package.json
+++ b/Packages/ButtplugUnity/package.json
@@ -5,7 +5,7 @@
     "email" : "kyle@nonpolynomial.com",
     "url" : "https://buttplug.io/"
   },
-  "version": "2.0.0",
+  "version": "2.1.0",
   "displayName": "Buttplug Unity",
   "description": "Buttplug Sex Toy Control Library support for Unity. For more info, see https://buttplug.io.",
   "unity": "2018.2"

--- a/README.md
+++ b/README.md
@@ -82,12 +82,6 @@ assure games that as much of the fuckery as possible stays on the Buttplug side.
 
 Yes.
 
-### Why can't I add the package from a git repo?
-
-Due to the large binaries required for the package, keeping Buttplug-Unity completely in a git repo
-would make the repo very large, very fast. Therefore we only keep text files in the repo, and bring
-in binaries as part of our build process.
-
 ### Can I use Buttplug Unity in my commercial game?
 
 Yes, Buttplug Unity falls under the same BSD 3-Clause license as the rest of the library, meaning


### PR DESCRIPTION
The current build on OpenUPM doesn't work since it built from the commit of the 2.0.0 tag. 

To fix that, I've updated the package version to 2.1.0 which should trigger a new build with the added binaries. I've also removed the note about the missing binaries in the ReadMe and updated the Changelog with v2.1.0.

Once this is merged in, we can tag the merge as `2.1.0` which will trigger the next build and include the binaries. 